### PR TITLE
Removed volumes from Docker Compose 

### DIFF
--- a/cti-stix-store/docker-compose.yml
+++ b/cti-stix-store/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   cti-stix-store:
     container_name: cti-stix-store
     build: .
-    volumes:
-     - .:/usr/share/cti-stix-store
     ports:
      - "3000:3000"
     links:


### PR DESCRIPTION
Removed volumes from Docker Compose in order to support working configuration on initial clone of repository.